### PR TITLE
👾 tex:curvenote format used custom environments

### DIFF
--- a/src/nodes/aside.ts
+++ b/src/nodes/aside.ts
@@ -1,4 +1,6 @@
 import { NodeSpec } from 'prosemirror-model';
+import { FormatTypes, LatexOptions } from '../serialize/tex/types';
+import { createLatexStatement } from '../serialize/tex/utils';
 import { NodeGroups, FormatSerialize } from './types';
 
 const aside: NodeSpec = {
@@ -21,5 +23,13 @@ export const toMarkdown: FormatSerialize = (state, node) => {
   state.write('```');
   state.closeBlock(node);
 };
+
+export const toTex: FormatSerialize = createLatexStatement(
+  (options: LatexOptions) => (options.format === FormatTypes.tex_curvenote ? 'aside' : 'marginpar'),
+  (state, node) => {
+    state.renderContent(node);
+  },
+  (options: LatexOptions) => ({ inline: options.format === FormatTypes.tex }),
+);
 
 export default aside;

--- a/src/nodes/callout.ts
+++ b/src/nodes/callout.ts
@@ -1,5 +1,6 @@
 import { NodeSpec } from 'prosemirror-model';
-import { latexStatement } from '../serialize/tex/utils';
+import { LatexOptions, FormatTypes } from '../serialize/tex/types';
+import { createLatexStatement } from '../serialize/tex/utils';
 import { NodeGroups, FormatSerialize } from './types';
 
 export enum CalloutKinds {
@@ -47,8 +48,11 @@ export const toMarkdown: FormatSerialize = (state, node) => {
   state.closeBlock(node);
 };
 
-export const toTex = latexStatement('callout', (state, node) => {
-  state.renderContent(node);
-});
+export const toTex = createLatexStatement(
+  (options: LatexOptions) => (options.format === FormatTypes.tex_curvenote ? 'callout' : 'framed'),
+  (state, node) => {
+    state.renderContent(node);
+  },
+);
 
 export default callout;

--- a/src/nodes/code.ts
+++ b/src/nodes/code.ts
@@ -1,4 +1,5 @@
-import { latexStatement } from '../serialize/tex/utils';
+import { FormatTypes, LatexOptions } from '../serialize/tex/types';
+import { createLatexStatement } from '../serialize/tex/utils';
 import { NodeGroups, NumberedNode, MyNodeSpec, FormatSerialize } from './types';
 import { getNumberedAttrs, getNumberedDefaultAttrs, setNumberedAttrs } from './utils';
 
@@ -54,9 +55,11 @@ export const toMarkdown: FormatSerialize = (state, node) => {
   state.closeBlock(node);
 };
 
-// TODO: language
-export const toTex: FormatSerialize = latexStatement('verbatim', (state, node) => {
-  state.text(node.textContent, false);
-});
+export const toTex = createLatexStatement(
+  (options: LatexOptions) => (options.format === FormatTypes.tex_curvenote ? 'code' : 'verbatim'),
+  (state, node) => {
+    state.renderContent(node);
+  },
+);
 
 export default code;

--- a/src/nodes/equation.ts
+++ b/src/nodes/equation.ts
@@ -1,5 +1,5 @@
 import { NodeGroups, FormatSerialize, MyNodeSpec, NumberedNode } from './types';
-import { latexStatement } from '../serialize/tex/utils';
+import { createLatexStatement } from '../serialize/tex/utils';
 import { getAttr, getNumberedAttrs, getNumberedDefaultAttrs, setNumberedAttrs } from './utils';
 
 export type Attrs = NumberedNode & {
@@ -47,7 +47,7 @@ export const toMarkdown: FormatSerialize = (state, node) => {
   state.closeBlock(node);
 };
 
-export const toTex = latexStatement('equation', (state, node) => {
+export const toTex = createLatexStatement('equation', (state, node) => {
   // TODO: export the label if it isn't inline!
   state.text(node.textContent, false);
 });

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -60,7 +60,7 @@ export type NodeDef = {
 };
 
 export type FormatSerialize<S extends Schema<any, any> = any> = (
-  state: MarkdownSerializerState<S> & { delim?: string },
+  state: MarkdownSerializerState & { delim?: string },
   node: Node<S>,
   parent: Node<S>,
   index: number,

--- a/src/serialize/tex/index.ts
+++ b/src/serialize/tex/index.ts
@@ -1,9 +1,10 @@
 import { Node as ProsemirrorNode } from 'prosemirror-model';
 import { MarkdownSerializer } from 'prosemirror-markdown';
-import { blankTex, blankTexLines, latexStatement, TAB } from './utils';
+import { blankTex, blankTexLines, createLatexStatement, TAB } from './utils';
 import * as nodes from '../../nodes';
 import { isPlainURL } from '../markdown/utils';
 import { nodeNames } from '../../schemas';
+import { FormatTypes } from './types';
 
 export const texSerializer = new MarkdownSerializer(
   {
@@ -39,7 +40,7 @@ export const texSerializer = new MarkdownSerializer(
       state.closeBlock(node);
     },
     heading: nodes.Heading.toTex,
-    blockquote: latexStatement('quote', (state, node) => {
+    blockquote: createLatexStatement('quote', (state, node) => {
       state.renderContent(node);
     }),
     code_block: nodes.Code.toTex,
@@ -55,7 +56,7 @@ export const texSerializer = new MarkdownSerializer(
         }
       }
     },
-    ordered_list: latexStatement(
+    ordered_list: createLatexStatement(
       'enumerate',
       (state, node) => {
         state.renderList(node, TAB, () => '\\item ');
@@ -67,7 +68,7 @@ export const texSerializer = new MarkdownSerializer(
         },
       },
     ),
-    bullet_list: latexStatement('itemize', (state, node) => {
+    bullet_list: createLatexStatement('itemize', (state, node) => {
       state.renderList(node, TAB, () => '\\item ');
     }),
     list_item(state, node) {
@@ -82,13 +83,7 @@ export const texSerializer = new MarkdownSerializer(
     equation: nodes.Equation.toTex,
     // \usepackage{framed}
     callout: nodes.Callout.toTex,
-    aside: latexStatement(
-      'marginpar',
-      (state, node) => {
-        state.renderContent(node);
-      },
-      { inline: true },
-    ),
+    aside: nodes.Aside.toTex,
     variable: blankTexLines,
     display: blankTex,
     dynamic: blankTex,
@@ -135,6 +130,6 @@ export const texSerializer = new MarkdownSerializer(
   },
 );
 
-export function toTex(doc: ProsemirrorNode) {
-  return texSerializer.serialize(doc, { tightLists: true });
+export function toTex(doc: ProsemirrorNode, format: FormatTypes) {
+  return texSerializer.serialize(doc, { tightLists: true, format });
 }

--- a/src/serialize/tex/types.ts
+++ b/src/serialize/tex/types.ts
@@ -1,0 +1,22 @@
+import { MarkdownSerializerState } from 'prosemirror-markdown';
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+
+export enum FormatTypes {
+  'tex' = 'tex',
+  'tex_curvenote' = 'tex:curvenote',
+}
+
+export interface LatexOptions {
+  tightLists?: boolean | null;
+  format?: FormatTypes;
+}
+
+export interface LatexStatementOptions {
+  bracketOpts?: null | ((node: ProsemirrorNode) => string | null);
+  inline?: boolean;
+}
+
+export interface LatexSerializerState extends MarkdownSerializerState {
+  options: LatexOptions;
+  delim?: string;
+}

--- a/test/build.ts
+++ b/test/build.ts
@@ -51,6 +51,7 @@ export const tnodes = builders(schema, {
   math: { nodeType: 'math' },
   equation: { nodeType: 'equation' },
   abbr: { nodeType: 'abbr', title: 'Cascading Style Sheets' },
+  aside: { nodeType: 'aside' },
 });
 
 export const tdoc = (...args: Parameters<typeof tnodes.doc>) => tnodes.doc('', ...args);

--- a/test/tex.spec.ts
+++ b/test/tex.spec.ts
@@ -1,4 +1,5 @@
 import { Node } from 'prosemirror-model';
+import { FormatTypes } from '../src/serialize/tex/types';
 import { tnodes, tdoc } from './build';
 import { toTex } from '../src';
 
@@ -27,16 +28,33 @@ const {
   math,
   equation,
   callout,
+  aside,
 } = tnodes;
 
-const same = (text: string, doc: Node) => {
-  expect(toTex(doc)).toEqual(text);
+const same = (text: string, doc: Node, format: FormatTypes = FormatTypes.tex) => {
+  expect(toTex(doc, format)).toEqual(text);
+};
+
+const expectEnvironment = (name: string, doc: Node, format: FormatTypes = FormatTypes.tex) => {
+  expect(toTex(doc, format)).toEqual(`\\begin{${name}}\n  hello!\n\\end{${name}}`);
 };
 
 describe('Tex', () => {
   it('serializes a paragraph', () => same('hello!', tdoc(p('hello!'))));
+  it('serializes a callout', () => expectEnvironment('framed', tdoc(callout('hello!'))));
   it('serializes an ordered list', () =>
     same('\\begin{enumerate}\n  \\item hello\n\\end{enumerate}', tdoc(ol(li('hello')))));
   it('serializes an ordered list starting at "3"', () =>
     same('\\begin{enumerate}[resume]\n  \\item hello\n\\end{enumerate}', tdoc(ol3(li('hello')))));
+  it('serializes an aside', () => same('\\marginpar{\n  hello!\n}', tdoc(aside('hello!'))));
+  it('serializes a code_block', () => expectEnvironment('verbatim', tdoc(pre('hello!'))));
+});
+
+describe('Tex:curvenote', () => {
+  it('serializes a callout', () =>
+    expectEnvironment('callout', tdoc(callout('hello!')), FormatTypes.tex_curvenote));
+  it('serializes an aside', () =>
+    expectEnvironment('aside', tdoc(aside('hello!')), FormatTypes.tex_curvenote));
+  it('serializes a code_block', () =>
+    expectEnvironment('code', tdoc(pre('hello!')), FormatTypes.tex_curvenote));
 });


### PR DESCRIPTION
`toTex` now accepts a `format` option. This allows us to choose between returning vanilla latex or curvenote specific commands and environments, which when used with `.def` files that we provide separately will create richer renderings of the content. The formats values are `tex` and `tex:curvenote`.