### PR TITLE
🔧 switch from inline to an environment for captions [TeX]

### DIFF
--- a/src/nodes/figcaption.ts
+++ b/src/nodes/figcaption.ts
@@ -47,7 +47,7 @@ export const toMarkdown: MdFormatSerialize = (state, node) => {
 };
 
 export const toTex = createLatexStatement(
-  () => ({ command: 'caption' }),
+  () => ({ command: 'caption', inline: true }),
   (state, node) => state.renderInline(node),
 );
 

--- a/src/nodes/figure.ts
+++ b/src/nodes/figure.ts
@@ -81,6 +81,8 @@ export const toTex = createLatexStatement(
     const localId = state.options.localizeId?.(id ?? '') ?? id;
     const star = numbered ? '' : '*';
     // TODO: Based on align attr
+    // may have to modify string returned by state.renderContent(node);
+    // https://tex.stackexchange.com/questions/91566/syntax-similar-to-centering-for-right-and-left
     state.write('\\centering');
     const captionFirst = node.firstChild?.type.name === nodeNames.figcaption;
     if (localId && captionFirst) {


### PR DESCRIPTION
The previous inline caption command does not work well and introduces an additional line break in rendered latex documents. Captions should be an environment. This PR fixes that.