### PR TITLE
Add all rst admonitions to schema CalloutKinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 yalc.lock
 .yalc/
+*.DS_Store

--- a/src/nodes/callout.ts
+++ b/src/nodes/callout.ts
@@ -9,6 +9,14 @@ export enum CalloutKinds {
   'info' = 'info',
   'warning' = 'warning',
   'danger' = 'danger',
+  'note' = 'note',
+  'important' = 'important',
+  'admonition' = 'admonition',
+  'caution' = 'caution',
+  'error' = 'error',
+  'hint' = 'hint',
+  'tip' = 'tip',
+  'attention' = 'attention',
 }
 
 export type Attrs = {
@@ -33,6 +41,14 @@ const callout: NodeSpec = {
         if (dom.classList.contains(CalloutKinds.info)) return { kind: CalloutKinds.info };
         if (dom.classList.contains(CalloutKinds.warning)) return { kind: CalloutKinds.warning };
         if (dom.classList.contains(CalloutKinds.danger)) return { kind: CalloutKinds.danger };
+        if (dom.classList.contains(CalloutKinds.note)) return { kind: CalloutKinds.info };
+        if (dom.classList.contains(CalloutKinds.important)) return { kind: CalloutKinds.info };
+        if (dom.classList.contains(CalloutKinds.admonition)) return { kind: CalloutKinds.warning };
+        if (dom.classList.contains(CalloutKinds.caution)) return { kind: CalloutKinds.danger };
+        if (dom.classList.contains(CalloutKinds.error)) return { kind: CalloutKinds.warning };
+        if (dom.classList.contains(CalloutKinds.hint)) return { kind: CalloutKinds.info };
+        if (dom.classList.contains(CalloutKinds.tip)) return { kind: CalloutKinds.info };
+        if (dom.classList.contains(CalloutKinds.attention)) return { kind: CalloutKinds.warning };
         return { kind: CalloutKinds.info };
       },
       // aside is also parsed, and this is higher priority
@@ -51,12 +67,8 @@ function calloutKindToAdmonition(kind: CalloutKinds): string {
       return 'important';
     case CalloutKinds.info:
       return 'important';
-    case CalloutKinds.warning:
-      return 'warning';
-    case CalloutKinds.danger:
-      return 'danger';
     default:
-      return 'note';
+      return kind.toString();
   }
 }
 

--- a/test/myst.spec.ts
+++ b/test/myst.spec.ts
@@ -1,0 +1,20 @@
+import { fromMarkdown, toMarkdown } from '../src';
+
+const same = (snippet: string) => {
+  const transformed = toMarkdown(fromMarkdown(snippet, 'full'));
+  expect(transformed).toEqual(snippet);
+};
+
+describe('Markdown', () => {
+  it('parses a simple text', () => same('hello!'));
+  it('parses a simple text', () => same('```{note}\nhello!\n```'));
+  it('parses a simple text', () => same('```{important}\nhello!\n```'));
+  it('parses a simple text', () => same('```{admonition}\nhello!\n```'));
+  it('parses a simple text', () => same('```{caution}\nhello!\n```'));
+  it('parses a simple text', () => same('```{danger}\nhello!\n```'));
+  it('parses a simple text', () => same('```{error}\nhello!\n```'));
+  it('parses a simple text', () => same('```{hint}\nhello!\n```'));
+  it('parses a simple text', () => same('```{tip}\nhello!\n```'));
+  it('parses a simple text', () => same('```{warning}\nhello!\n```'));
+  it('parses a simple text', () => same('```{attention}\nhello!\n```'));
+});


### PR DESCRIPTION
This lets us round-trip all the rst admonition types. I tried to keep it backwards compatible (i.e. didn't change the behaviour of the existing `CalloutKinds` and made all the new `CalloutKinds` point to old kinds in `callout`). I'm sure there are a ton of implications with everything else touched by `schema`, but, hey, the new tests I wrote pass 😄 