### PR TITLE
Add JSON/YAML serialization/parser functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@wordpress/wordcount": "^3.2.2",
+    "js-yaml": "^4.1.0",
     "markdown-it": "^12.2.0",
     "markdown-it-myst": "^0.0.9",
     "nanoid": "^3.1.30",
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@types/jest": "^26.0.23",
+    "@types/js-yaml": "^4.0.5",
     "@types/jsdom": "^16.2.12",
     "@types/markdown-it": "^12.2.3",
     "@types/mocha": "^8.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ export * from './utils';
 export { nodeNames } from './types';
 export { ReferenceKind, CaptionKind } from './nodes/types';
 
-export { fromHTML, fromText, fromMarkdown } from './parse';
-export { toHTML, toMarkdown, toTex, toText, TexFormatTypes } from './serialize';
+export * from './parse';
+export * from './serialize';
 
 export * as server from './server';
 export * as process from './process';

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -1,3 +1,5 @@
 export { fromHTML } from './html';
 export { fromMarkdown } from './markdown';
 export { fromText } from './text';
+export { fromJSON } from './json';
+export { fromYAML } from './yaml';

--- a/src/parse/json/index.ts
+++ b/src/parse/json/index.ts
@@ -1,0 +1,16 @@
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { getSchema, UseSchema } from '../../schemas';
+
+export function fromJSON(
+  content: string | Record<string, any>,
+  useSchema: UseSchema,
+): ProsemirrorNode {
+  const schema = getSchema(useSchema);
+  const data = typeof content === 'string' ? JSON.parse(content) : content;
+  const state = EditorState.fromJSON(
+    { schema },
+    { doc: data, selection: { type: 'text', anchor: 0, head: 0 } },
+  );
+  return state.doc;
+}

--- a/src/parse/yaml/index.ts
+++ b/src/parse/yaml/index.ts
@@ -1,0 +1,8 @@
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+import yaml from 'js-yaml';
+import { UseSchema } from '../../schemas';
+import { fromJSON } from '../json';
+
+export function fromYAML(input: string, useSchema: UseSchema): ProsemirrorNode {
+  return fromJSON(JSON.stringify(yaml.load(input)), useSchema);
+}

--- a/src/serialize/index.ts
+++ b/src/serialize/index.ts
@@ -3,3 +3,5 @@ export { toTex } from './tex';
 export { toText } from './text';
 export { toHTML } from './html';
 export { TexFormatTypes } from './types';
+export { toJSON } from './json';
+export { toYAML } from './yaml';

--- a/src/serialize/json/index.ts
+++ b/src/serialize/json/index.ts
@@ -1,0 +1,5 @@
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+
+export function toJSON(doc: ProsemirrorNode): string {
+  return JSON.stringify(doc.toJSON());
+}

--- a/src/serialize/yaml/index.ts
+++ b/src/serialize/yaml/index.ts
@@ -1,0 +1,6 @@
+import yaml from 'js-yaml';
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+
+export function toYAML(doc: ProsemirrorNode): string {
+  return yaml.dump(doc.toJSON());
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { Step as PMStep } from 'prosemirror-transform';
 import { EditorState } from 'prosemirror-state';
 import { collab, receiveTransaction } from 'prosemirror-collab';
 import { Node } from 'prosemirror-model';
-import { fromHTML } from './parse';
+import { fromHTML } from './parse/html';
 
 import { Parser } from './parse/types';
 import { getSchema, UseSchema } from './schemas';

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/js-yaml@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/jsdom@^16.2.12":
   version "16.2.13"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.13.tgz#126c8b7441b159d6234610a48de77b6066f1823f"
@@ -3210,6 +3215,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsdom@^16.4.0, jsdom@^16.7.0:
   version "16.7.0"


### PR DESCRIPTION
This follows the existing `serialize`/`parse` pattern to add `toJSON`/`fromJSON` and `toYAML`/`fromYAML` functions for `EditorState.doc` conversions.