### PR TITLE
📐  scale wide tables to fit page

### DIFF
--- a/src/nodes/table.ts
+++ b/src/nodes/table.ts
@@ -144,6 +144,8 @@ export function renderNodeToLatex(state: TexSerializerState, node: Node<any>) {
   state.isInTable = true;
 
   // Note we can put borders in with `|*{3}{c}|` and similarly on the multicolumn below
+  state.write('\\adjustbox{max width=\\textwidth}{%');
+  state.ensureNewLine();
   state.write(`\\begin{tabular}{*{${numColumns}}{c}}`);
   state.ensureNewLine();
   const dedent = indent(state);
@@ -186,6 +188,7 @@ export function renderNodeToLatex(state: TexSerializerState, node: Node<any>) {
   state.ensureNewLine();
   dedent();
   state.write('\\end{tabular}');
+  state.write('}');
   state.closeBlock(node);
   state.isInTable = false;
 }

--- a/test/tex.tables.spec.ts
+++ b/test/tex.tables.spec.ts
@@ -12,13 +12,14 @@ const same = (text: string, doc: Node, format: TexFormatTypes = TexFormatTypes.t
 describe('Tex Tables', () => {
   it('serializes a simple table', () => {
     same(
-      `\\begin{tabular}{*{2}{c}}
+      `\\adjustbox{max width=\\textwidth}{%
+\\begin{tabular}{*{2}{c}}
   \\hline
   Col 1 & Col 1 \\\\
   \\hline
   data 1 & data 2 \\\\
   \\hline
-\\end{tabular}`,
+\\end{tabular}}`,
       tdoc(
         table(
           table_row(table_header(p('Col 1')), table_header(p('Col 1'))),
@@ -30,13 +31,14 @@ describe('Tex Tables', () => {
 
   it('serializes a simple table', () => {
     same(
-      `\\begin{tabular}{*{2}{c}}
+      `\\adjustbox{max width=\\textwidth}{%
+\\begin{tabular}{*{2}{c}}
   \\hline
   Col 1 & \\(\\displaystyle \\mu \\) \\\\
   \\hline
   data 1 & data 2 \\\\
   \\hline
-\\end{tabular}`,
+\\end{tabular}}`,
       tdoc(
         table(
           table_row(table_header(p('Col 1')), table_header(equation('\\mu'))),


### PR DESCRIPTION
Tables can be wider than the page can accommodate, especially if these are coming from `pandas`. This change is a first base solution to just scale to page width.

![image](https://user-images.githubusercontent.com/1473646/154322562-77cdbafd-9ff4-4c50-8700-df81f6e86aa4.png)

Further improvements down the road could force wrapping etc to reduce the scaling, but this avoids tables flowing out of the page area (width-wise)