### PR TITLE
🤫 Remove marks for math and equations

### DIFF
--- a/src/nodes/equation.ts
+++ b/src/nodes/equation.ts
@@ -25,6 +25,7 @@ const equation: MyNodeSpec<Attrs, Math> = {
   marks: '',
   // The view treat the node as a leaf, even though it technically has content
   atom: true,
+  whitespace: 'pre',
   code: true,
   attrs: {
     ...getNumberedDefaultAttrs(),

--- a/src/nodes/equation.ts
+++ b/src/nodes/equation.ts
@@ -22,6 +22,7 @@ const equation: MyNodeSpec<Attrs, Math> = {
   // Content can have display elements inside of it for dynamic equations
   content: `(${NodeGroups.text} | display)*`,
   draggable: false,
+  marks: '',
   // The view treat the node as a leaf, even though it technically has content
   atom: true,
   code: true,

--- a/src/nodes/math.ts
+++ b/src/nodes/math.ts
@@ -9,6 +9,7 @@ const math: MyNodeSpec<Attrs, InlineMath> = {
   // Content can have display elements inside of it for dynamic equations
   content: `(${NodeGroups.text} | display)*`,
   inline: true,
+  marks: '',
   draggable: false,
   // The view treat the node as a leaf, even though it technically has content
   atom: true,


### PR DESCRIPTION
This should disallow textbf textit etc in math mode export. This can occasionally cause problems with bracket placements.

See curvenote/editor#102